### PR TITLE
amm_arb improvements

### DIFF
--- a/hummingbot/strategy/amm_arb/amm_arb_config_map.py
+++ b/hummingbot/strategy/amm_arb/amm_arb_config_map.py
@@ -4,6 +4,7 @@ from hummingbot.client.config.config_validators import (
     validate_bool,
     validate_connector,
     validate_decimal,
+    validate_float,
     validate_int,
     validate_market_trading_pair,
 )
@@ -153,4 +154,22 @@ amm_arb_config_map = {
         default=Decimal("1"),
         validator=lambda v: validate_decimal(v),
         type_str="decimal"),
+    "pause_after_arb_taken": ConfigVar(
+        key="pause_after_arb_taken",
+        prompt="What is the minimum wait time before trying the next arb opportunity (Enter time seconds)? >>> ",
+        default=float("30"),
+        validator=lambda v: validate_float(v),
+        type_str="float"),
+    "failed_orders_count_before_long_pause": ConfigVar(
+        key="failed_orders_count_before_long_pause",
+        prompt="How many failed orders before entering long pause state? >>> ",
+        default=3,
+        validator=lambda v: validate_int(v, min_value=0),
+        type_str="int"),
+    "long_pause_duration_hours": ConfigVar(
+        key="long_pause_duration_hours",
+        prompt="How long to pause for on failed orders (Enter value in hours)? >>> ",
+        default=1,
+        validator=lambda v: validate_int(v, min_value=0),
+        type_str="int"),
 }

--- a/hummingbot/strategy/amm_arb/amm_arb_config_map.py
+++ b/hummingbot/strategy/amm_arb/amm_arb_config_map.py
@@ -156,20 +156,20 @@ amm_arb_config_map = {
         type_str="decimal"),
     "pause_after_arb_taken": ConfigVar(
         key="pause_after_arb_taken",
-        prompt="What is the minimum wait time before trying the next arb opportunity (Enter time seconds)? >>> ",
+        prompt="What is the minimum wait time before trying the next arb opportunity in seconds? >>> ",
         default=float("30"),
-        validator=lambda v: validate_float(v),
+        validator=lambda v: validate_float(v, min_value = 0),
         type_str="float"),
     "failed_orders_count_before_long_pause": ConfigVar(
         key="failed_orders_count_before_long_pause",
-        prompt="How many failed orders before entering long pause state? >>> ",
+        prompt="How many failed orders before entering long pause state? 0 to disable >>> ",
         default=3,
-        validator=lambda v: validate_int(v, min_value=0),
+        validator=lambda v: validate_int(v, min_value = 0),
         type_str="int"),
     "long_pause_duration_hours": ConfigVar(
         key="long_pause_duration_hours",
-        prompt="How long to pause for on failed orders (Enter value in hours)? >>> ",
+        prompt="How long to pause for on failed orders in hours? >>> ",
         default=1,
-        validator=lambda v: validate_int(v, min_value=0),
+        validator=lambda v: validate_float(v, min_value = 0),
         type_str="int"),
 }

--- a/hummingbot/strategy/amm_arb/amm_arb_config_map.py
+++ b/hummingbot/strategy/amm_arb/amm_arb_config_map.py
@@ -171,5 +171,5 @@ amm_arb_config_map = {
         prompt="How long to pause for on failed orders in hours? >>> ",
         default=1,
         validator=lambda v: validate_float(v, min_value = 0),
-        type_str="int"),
+        type_str="float"),
 }

--- a/hummingbot/strategy/amm_arb/start.py
+++ b/hummingbot/strategy/amm_arb/start.py
@@ -7,9 +7,10 @@ from hummingbot.connector.gateway.common_types import Chain
 from hummingbot.connector.gateway.gateway_price_shim import GatewayPriceShim
 from hummingbot.core.rate_oracle.rate_oracle import RateOracle
 from hummingbot.core.utils.fixed_rate_source import FixedRateSource
-from hummingbot.strategy.amm_arb.amm_arb import AmmArbStrategy
-from hummingbot.strategy.amm_arb.amm_arb_config_map import amm_arb_config_map
 from hummingbot.strategy.market_trading_pair_tuple import MarketTradingPairTuple
+
+from .amm_arb import AmmArbStrategy
+from .amm_arb_config_map import amm_arb_config_map
 
 
 def start(self):

--- a/hummingbot/strategy/amm_arb/start.py
+++ b/hummingbot/strategy/amm_arb/start.py
@@ -26,6 +26,9 @@ def start(self):
     gateway_transaction_cancel_interval = amm_arb_config_map.get("gateway_transaction_cancel_interval").value
     rate_oracle_enabled = amm_arb_config_map.get("rate_oracle_enabled").value
     quote_conversion_rate = amm_arb_config_map.get("quote_conversion_rate").value
+    pause_after_arb_taken = amm_arb_config_map.get("pause_after_arb_taken").value
+    long_pause_duration = float(amm_arb_config_map.get("long_pause_duration_hours").value * 3600)
+    failed_orders_count_before_long_pause = amm_arb_config_map.get("failed_orders_count_before_long_pause").value
 
     self._initialize_markets([(connector_1, [market_1]), (connector_2, [market_2])])
     base_1, quote_1 = market_1.split("-")
@@ -75,4 +78,7 @@ def start(self):
                               concurrent_orders_submission=concurrent_orders_submission,
                               gateway_transaction_cancel_interval=gateway_transaction_cancel_interval,
                               rate_source=rate_source,
+                              pause_after_arb_taken=pause_after_arb_taken,
+                              failed_orders_count_before_long_pause=failed_orders_count_before_long_pause,
+                              long_pause_duration=long_pause_duration,
                               )

--- a/hummingbot/templates/conf_amm_arb_strategy_TEMPLATE.yml
+++ b/hummingbot/templates/conf_amm_arb_strategy_TEMPLATE.yml
@@ -2,7 +2,7 @@
 ###   AMM Arbitrage strategy config   ###
 ##########################################
 
-template_version: 6
+template_version: 7
 strategy: null
 
 # The following configurations are only required for the AMM arbitrage trading strategy
@@ -41,7 +41,16 @@ debug_price_shim: false
 gateway_transaction_cancel_interval: 600
 
 # What rate source should be used for quote assets pair - between fixed_rate_source and rate_oracle_source?
-rate_oracle_enabled: true
+rate_oracle_enabled: false
 
 # What is the fixed_rate used to convert quote assets?
 quote_conversion_rate: 1
+
+# Rate limit arb taking
+# What is the minimum wait time before trying the next arb opportunity (Enter time seconds)
+pause_after_arb_taken: 0
+# How many failed orders before the bot takes a long pause
+failed_orders_count_before_long_pause: 3
+# The duration of the long pause in hours
+long_pause_duration_hours: 1
+


### PR DESCRIPTION
background: https://github.com/Joystream/hummingbot-ops/issues/13
Implements pausing under two conditions:
  - An arb opportunity was available to take, irrespective if it was taken or not, we pause for a configurable number of seconds: `pause_after_arb_taken` (integer). Default set to 30s. Set it to zero to disable this feature.
  - After detecting a configurable number of failed orders `failed_orders_count_before_long_pause` the bot pauses taking arb opportunities for a configurable number of hours `long_pause_duration_hours` (integer) - Default set to 1h. Configuring it to zero would disable this feature.

